### PR TITLE
feat/#7/컬러팔레트 설정

### DIFF
--- a/.vite/deps/_metadata.json
+++ b/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "77d19c7f",
+  "configHash": "da805955",
+  "lockfileHash": "8d8931be",
+  "browserHash": "d0e69c96",
+  "optimized": {},
+  "chunks": {}
+}

--- a/.vite/deps/package.json
+++ b/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,18 @@
   src: url('components/fonts/Pretendard-Thin.woff');
 }
 
+@theme {
+  --color-white: #fffefc;
+  --color-primary: #ffba42;
+  --color-primary-200: #fddda7;
+  --color-grey-100: #efefef;
+  --color-grey-200: #adadad;
+  --color-grey-300: #828282;
+  --color-grey-500: #6a7282;
+  --color-grey-700: #364153;
+  --color-black: #000000;
+}
+
 @layer base {
   html {
     font-family: 'Pretendard-Regualr';


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
  closed #7 

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
index.css 파일에 컬러팔레트 지정해주는 코드 추가

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
**사용 방법!!**
텍스트 컬러 변경 시
text-원하는 컬러 / text-원하는 컬러-원하는 컬러 숫자

ex.
```
<h1 class="text-grey-200">hello</h1>
<h1 class="text-primary">hello2</h1>
```

백그라운드 컬러 변경 원할 시 text 대신 bg를 써주면 됩니다!!!
ex. **<h1 class="bg-primary">hello2</h1>**

+) VS code에 Tailwind CSS IntelliSense / Tailwind Documentation 요렇게 두개 플러그인 받아줬더니 훨씬 편합니다!!!
Tailwind CSS IntelliSense -> 클래스 더 편하게 작성해줄 수 있도록 해줌
Tailwind Documentation -> 사용법 기억 안날 때 Mac: cmd + ctrl + t / Windows: ctrl + alt + t 단축어를 누르면 원하는 기능 설명 찾을 수 있음!!!

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
