### PR TITLE
Feat/#28/커뮤니티 게시글 목록 페이지

### DIFF
--- a/src/assets/DropdownSign.svg
+++ b/src/assets/DropdownSign.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 10L12 15L7 10" stroke="#364153" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/community/Dropdown.jsx
+++ b/src/components/community/Dropdown.jsx
@@ -1,0 +1,38 @@
+import React, { useState, useEffect, useRef } from 'react'
+import DropdownSign from '@/assets/DropdownSign.svg'
+
+const Dropdown = ({ label }) => {
+  const [open, setOpen] = useState(false)
+  const emotionList = ['전체', '정겨움', '편안함', '조용함', '활기참', '소박함', '세심함']
+  const areaList = ['전체', '이태원', '한남동', '후암동', '효창동', '용문동', '청파동', '해방촌']
+
+  let options = []
+  label === '감정' ? (options = emotionList) : label === '동네' ? (options = areaList) : ''
+
+  return (
+    <div>
+      <button
+        type='button'
+        onClick={() => {
+          setOpen((o) => !o)
+        }}
+        className='flex items-center justify-center w-[18.72vw] h-[3.08vh] bg-grey-100 cursor-pointer rounded-[5px] font-[SemiBold] text-[12px] text-grey-700'
+      >
+        {label}
+        <img src={DropdownSign} />
+      </button>
+
+      {open && (
+        <div className='flex flex-col bg-grey-100 rounded-[10px] mt-[1px] font-[SemiBold] text-[0.625rem] text-grey-700 overflow-hidden'>
+          {options.map((opt) => (
+            <button className='hover:bg-primary-300 p-[5px]' key={opt}>
+              {opt}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Dropdown

--- a/src/components/community/Dropdown.jsx
+++ b/src/components/community/Dropdown.jsx
@@ -26,7 +26,7 @@ const Dropdown = ({ label }) => {
   label === '감정' ? (options = emotionList) : label === '동네' ? (options = areaList) : ''
 
   return (
-    <div ref={rootRef}>
+    <div ref={rootRef} className='relative'>
       <button
         type='button'
         onClick={() => {
@@ -39,7 +39,7 @@ const Dropdown = ({ label }) => {
       </button>
 
       {open && (
-        <div className='flex flex-col bg-grey-100 rounded-[10px] mt-[1px] font-[SemiBold] text-[0.625rem] text-grey-700 overflow-hidden'>
+        <div className='flex flex-col bg-grey-100 rounded-[10px] w-[18.72vw] mt-[1px] font-[SemiBold] text-[0.625rem] text-grey-700 overflow-hidden absolute top-full left-0 z-50'>
           {options.map((opt) => (
             <button
               className='hover:bg-primary-300 p-[5px]'

--- a/src/components/community/Dropdown.jsx
+++ b/src/components/community/Dropdown.jsx
@@ -5,27 +5,56 @@ const Dropdown = ({ label }) => {
   const [open, setOpen] = useState(false)
   const emotionList = ['전체', '정겨움', '편안함', '조용함', '활기참', '소박함', '세심함']
   const areaList = ['전체', '이태원', '한남동', '후암동', '효창동', '용문동', '청파동', '해방촌']
+  const [displayLabel, setDisplayLabel] = useState(label)
+  const [filtered, setFiltered] = useState(false)
+
+  const rootRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onMouseDown = (e) => {
+      if (!rootRef.current?.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', onMouseDown, { capture: false })
+    return () => document.removeEventListener('mousedown', onMouseDown, { capture: false })
+  }, [open])
 
   let options = []
   label === '감정' ? (options = emotionList) : label === '동네' ? (options = areaList) : ''
 
   return (
-    <div>
+    <div ref={rootRef}>
       <button
         type='button'
         onClick={() => {
           setOpen((o) => !o)
         }}
-        className='flex items-center justify-center w-[18.72vw] h-[3.08vh] bg-grey-100 cursor-pointer rounded-[5px] font-[SemiBold] text-[12px] text-grey-700'
+        className={`flex items-center justify-center w-[18.72vw] h-[3.08vh] bg-grey-100 cursor-pointer rounded-[5px] font-[SemiBold] text-[12px] text-grey-700 ${filtered ? 'bg-primary-300' : 'bg-grey-100'}`}
       >
-        {label}
+        {displayLabel}
         <img src={DropdownSign} />
       </button>
 
       {open && (
         <div className='flex flex-col bg-grey-100 rounded-[10px] mt-[1px] font-[SemiBold] text-[0.625rem] text-grey-700 overflow-hidden'>
           {options.map((opt) => (
-            <button className='hover:bg-primary-300 p-[5px]' key={opt}>
+            <button
+              className='hover:bg-primary-300 p-[5px]'
+              key={opt}
+              onClick={() => {
+                if (opt === '전체') {
+                  setDisplayLabel(label)
+                  setFiltered(false)
+                } else {
+                  setDisplayLabel(opt)
+                  setFiltered(true)
+                }
+                setOpen(false)
+              }}
+            >
               {opt}
             </button>
           ))}

--- a/src/components/community/Post.jsx
+++ b/src/components/community/Post.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import Tag from './Tag.jsx'
+
+const Post = () => {
+  return (
+    <div className='flex flex-col relative px-[3.846vw] w-[76.67vw] h-[44.312vh] rounded-[10px] shadow-[0_2px_7px_3px_rgba(0,0,0,0.1)] bg-white'>
+      <div className='flex gap-[0.5rem] items-center ml-[0.5vw] mt-[1.6vh]'>
+        <img className='w-[5.13vw] h-[5.13vw] rounded-full bg-grey-100 border-none' />
+        <p className='font-[Medium] text-[0.75rem]'>사용자 1</p>
+      </div>
+      <img
+        className='w-[68.974vw] h-[29.146vh] bg-grey-100 rounded-[10px] mt-[1.6vh]'
+        alt='골목 과거 사진'
+      />
+      <p className='whitespace-pre-line mt-[1.9vh] text-[0.75rem]'>
+        {`겨울마다 이 골목에서 붕어빵 먹던 기억이 나네요...
+          이젠 못먹는 게 아쉬워요`}
+      </p>
+      <div className='flex gap-[6px] mt-[0.947vh] mb-[1.78vh]'>
+        <Tag label={'따뜻함'} />
+        <Tag label={'후암동'} />
+        <Tag label={'사라진 가게'} />
+      </div>
+    </div>
+  )
+}
+
+export default Post

--- a/src/components/community/Post.jsx
+++ b/src/components/community/Post.jsx
@@ -1,21 +1,29 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Tag from './Tag.jsx'
 
-const Post = () => {
+const Post = ({ text }) => {
+  const [expanded, setExpanded] = useState(false)
+
+  const displayedText = expanded ? text : text.length > 25 ? text.slice(0, 25) : text
+
   return (
-    <div className='flex flex-col relative px-[3.846vw] w-[76.67vw] h-[44.312vh] rounded-[10px] shadow-[0_2px_7px_3px_rgba(0,0,0,0.1)] bg-white'>
+    <div className='flex flex-col relative px-[3.846vw] w-[76.67vw] rounded-[10px] shadow-[0_2px_7px_3px_rgba(0,0,0,0.1)] bg-white'>
       <div className='flex gap-[0.5rem] items-center ml-[0.5vw] mt-[1.6vh]'>
         <img className='w-[5.13vw] h-[5.13vw] rounded-full bg-grey-100 border-none' />
         <p className='font-[Medium] text-[0.75rem]'>사용자 1</p>
       </div>
       <img
-        className='w-[68.974vw] h-[29.146vh] bg-grey-100 rounded-[10px] mt-[1.6vh]'
+        className='w-[68.974vw] !h-[29.146vh] bg-grey-100 rounded-[10px] mt-[1.6vh]'
         alt='골목 과거 사진'
       />
-      <p className='whitespace-pre-line mt-[1.9vh] text-[0.75rem]'>
-        {`겨울마다 이 골목에서 붕어빵 먹던 기억이 나네요...
-          이젠 못먹는 게 아쉬워요`}
-      </p>
+      <div className='flex mt-[1.9vh] text-[0.75rem]'>
+        <p className='whitespace-pre-line'>{displayedText}</p>
+        {text.length > 25 && (
+          <button className='text-grey-300 ml-[0.2rem]' onClick={() => setExpanded(true)}>
+            {expanded ? '' : '더 보기'}
+          </button>
+        )}
+      </div>
       <div className='flex gap-[6px] mt-[0.947vh] mb-[1.78vh]'>
         <Tag label={'따뜻함'} />
         <Tag label={'후암동'} />

--- a/src/components/community/Tag.jsx
+++ b/src/components/community/Tag.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Tag = ({ label }) => {
+  return (
+    <div className='bg-grey-100 rounded-[5px] py-[2px] px-[6.5px] text-[0.75rem]'># {label}</div>
+  )
+}
+
+export default Tag

--- a/src/components/onboarding/ProgressBar.jsx
+++ b/src/components/onboarding/ProgressBar.jsx
@@ -11,7 +11,7 @@ const ProgressBar = ({ step, totalSteps = 3, onBack }) => {
   }, [])
 
   return (
-    <div className='flex ml-[5.9vw] mt-[25.48px]'>
+    <div className='flex ml-[5.9vw] mt-[25.48px] bg-white'>
       <img
         className='mr-[3.44vw] w-[6.58px] h-[15.28px] hover:cursor-pointer'
         src={Return}

--- a/src/components/shared/Header.jsx
+++ b/src/components/shared/Header.jsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom'
 const Header = ({ label }) => {
   const navigate = useNavigate()
   return (
-    <div className='fixed top-0 left-0 right-0 z-50 bg-white flex items-center relative w-[100vw] h-[7.11vh] border-b-[1px] border-b-grey-100 shadow-[0_2px_2px_#EFEFEF]'>
+    <div className='fixed top-0 left-0 right-0 z-50 bg-white flex items-center w-[100vw] h-[7.11vh] border-b-[1px] border-b-grey-100 shadow-[0_2px_2px_#EFEFEF]'>
       <img
         src={Return}
         alt='return'

--- a/src/components/shared/Header2.jsx
+++ b/src/components/shared/Header2.jsx
@@ -7,7 +7,7 @@ const Header2 = ({ label1, label2 }) => {
 
   return (
     <div>
-      <div className='fixed top-0 left-0 right-0 z-50 bg-white flex items-center relative w-[100vw] h-[7.11vh] border-b-[1px] border-b-grey-100 shadow-[0_2px_2px_#EFEFEF]'>
+      <div className='fixed top-0 left-0 right-0 z-50 bg-white flex items-center w-[100vw] h-[7.11vh] border-b-[1px] border-b-grey-100 shadow-[0_2px_2px_#EFEFEF]'>
         <img
           src={Return}
           alt='return'

--- a/src/pages/CommunityPostList.jsx
+++ b/src/pages/CommunityPostList.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import Dropdown from '@/components/community/Dropdown.jsx'
+import Post from '@/components/community/Post.jsx'
+import Header2 from '@/components/shared/Header2.jsx'
+import Footer from '@/components/shared/Footer.jsx'
+
+const CommunityPostList = () => {
+  return (
+    <div>
+      <Header2 label1={'피드'} label2={'내 글 모음'} />
+      <div className='px-[10.769vw] pt-[7.11vh] pb-[10vh] bg-white'>
+        <div className='flex gap-[1.54vw] my-[2.49vh]'>
+          <Dropdown label={'감정'} />
+          <Dropdown label={'동네'} />
+        </div>
+        <div className='flex flex-col gap-[3.91vh]'>
+          <Post
+            text={'겨울마다 이 골목에서 붕어빵 먹던 기억이 나네요...\n 이젠 못먹는 게 아쉬워요'}
+          />
+          <Post
+            text={'겨울마다 이 골목에서 붕어빵 먹던 기억이 나네요...\n 이젠 못먹는 게 아쉬워요'}
+          />
+        </div>
+      </div>
+      <Footer selectedMenu={'community'} />
+    </div>
+  )
+}
+
+export default CommunityPostList

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -30,7 +30,7 @@ const Login = () => {
   }
 
   return (
-    <div className='flex flex-col justify-center items-center justify-items-center'>
+    <div className='flex flex-col justify-center items-center justify-items-center bg-white'>
       <img className='mt-[18.36vh]' src={Logo} />
       <form className='flex flex-col gap-[1.184vh] mt-[5.094vh]'>
         <AuthBox

--- a/src/pages/OnBoardingPage.jsx
+++ b/src/pages/OnBoardingPage.jsx
@@ -47,7 +47,7 @@ const OnBoardingPage = () => {
   return (
     <>
       <ProgressBar step={step} totalSteps={steps.length} onBack={prevStep} />
-      <div className='flex flex-col justify-center items-center justify-items-center'>
+      <div className='flex flex-col justify-center items-center justify-items-center bg-white'>
         <p
           className='font-[SemiBold] text-grey-700 mt-[7.345vh] text-[20px] text-center'
           dangerouslySetInnerHTML={{ __html: steps[step].question }}
@@ -61,7 +61,7 @@ const OnBoardingPage = () => {
           />
         </div>
       </div>
-      <div className='absolute bottom-[11.14vh] flex justify-between w-full px-[6.67vw]'>
+      <div className='absolute bottom-[11.14vh] flex justify-between w-full px-[6.67vw] bg-white'>
         <FooterBtn onClick={goToLogin} text={'건너뛰기'} />
         <FooterBtn onClick={nextStep} text={step < steps.length - 1 ? '다음' : '시작하기'} />
       </div>

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -55,7 +55,7 @@ const Signup = () => {
   }
 
   return (
-    <div className='flex flex-col justify-center items-center justify-items-center'>
+    <div className='flex flex-col justify-center items-center justify-items-center bg-white'>
       <img className='mt-[11.492vh]' src={Logo} alt='Logo' />
       <img className='mt-[3.08vh]' src={SignupImg} alt='SignupImg' />
       <form>


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
  closed #28 

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
커뮤니티 게시글 목록 페이지 구현했습니다.
- 커뮤니티 게시글 컴포넌트 생성
- 드롭다운 컴포넌트 생성
- 태그 컴포넌트 생성

현재 화면은 연동 데이터를 기반으로 작성된 것이 아니며, 추후 필터링 기능과 API 연동을 통해 받아온 데이터로 화면이 출력되도록 수정할 예정입니다.

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
Header의 z-index 설정 오류로 상단에 정상적으로 표시되지 않는 문제가 있어 수정해두었습니다.
새로 수정한 header로 작업 부탁드립니다!

- 헤더 높이: 7.11vh 
- 푸터 높이: 7.464vh

화면 구현 시 참고 부탁드립니다!!

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
[아이폰 12 기준 화면]
<img width="293" height="635" alt="스크린샷 2025-08-15 오전 3 03 05" src="https://github.com/user-attachments/assets/e5959b76-ee45-40d7-805e-49f2a3ea06a4" />
